### PR TITLE
Improving royale mode

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -326,7 +326,7 @@
 	CHECK_TICK
 
 	//AI laws
-	parts += law_report()
+//	parts += law_report()
 
 	CHECK_TICK
 
@@ -335,9 +335,9 @@
 
 	CHECK_TICK
 	//Medals
-	parts += medal_report()
+//	parts += medal_report()
 	//Station Goals
-	parts += goal_report()
+//	parts += goal_report()
 
 	listclearnulls(parts)
 
@@ -418,11 +418,11 @@
 					parts += "<span class='greentext'>You managed to survive the events on [station_name()] as [M.real_name].</span>"
 			else
 				parts += "<div class='panel greenborder'>"
-				parts += "<span class='greentext'>You managed to survive the events on [station_name()] as [M.real_name].</span>"
+				parts += "<span class='greentext'>You managed to survive the [pick("slaughterfest", "bloodbath", "clusterfuck", "battle royale")] on [station_name()] as [M.real_name].</span>"
 
 		else
 			parts += "<div class='panel redborder'>"
-			parts += "<span class='redtext'>You did not survive the events on [station_name()]...</span>"
+			parts += "<span class='redtext'>You did not survive the [pick("slaughterfest", "bloodbath", "clusterfuck", "battle royale")] on [station_name()]...</span>"
 
 		if(CONFIG_GET(flag/allow_crew_objectives))
 			if(M.mind.current && LAZYLEN(M.mind.crew_objectives))

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -360,11 +360,11 @@
 		if(station_evacuated)
 			parts += "<BR>[GLOB.TAB]Evacuation Rate: <B>[popcount[POPCOUNT_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_ESCAPEES]/total_players)]%)</B>"
 			parts += "[GLOB.TAB](on emergency shuttle): <B>[popcount[POPCOUNT_SHUTTLE_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_SHUTTLE_ESCAPEES]/total_players)]%)</B>"
-		parts += "[GLOB.TAB]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
+//		parts += "[GLOB.TAB]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
 		if(SSblackbox.first_death)
 			var/list/ded = SSblackbox.first_death
 			if(ded.len)
-				parts += "[GLOB.TAB]First Death: <b>[ded["name"]], [ded["role"]], at [ded["area"]]. Damage taken: [ded["damage"]].[ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""]</b>"
+				parts += "[GLOB.TAB]First Death: <b>[ded["name"]], at [ded["area"]]. Damage taken: [ded["damage"]].[ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""]</b>"
 			//ignore this comment, it fixes the broken sytax parsing caused by the " above
 			else
 				parts += "[GLOB.TAB]<i>Nobody died this shift!</i>"

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -12,7 +12,7 @@
         <span class='notice'>Loot drops will periodically rain from the sky in random locations</span>\n\
         <span class='notice'>Random events will keep things spicy from time to time, stay on your toes!</span>\n\
 	    <span class='danger'>Mild banter is fine, but don't be toxic to others unless you want to be smited</span>"
-    var/winner
+    var/mob/winner
 
 /datum/game_mode/battle_royale/check_win()
     var/player_list = get_sentient_mobs()
@@ -33,3 +33,14 @@
 /datum/game_mode/battle_royale/check_finished()
     if(winner)
         return TRUE
+
+/datum/game_mode/battle_royale/special_report()
+    if(winner == "draw")
+        to_chat(world, "<span class='ratvar'><font size=12>Everybody died!</font></span>")
+        return "<div class='panel redborder'><span class='redtext big'>Nobody claims victory!</span></div>"
+    if(winner?.real_name)
+        to_chat(world, "<span class='ratvar'><font size=12>[winner.real_name] claims victory!</font></span>")
+        return "<div class='panel redborder'><span class='greentext big'>[winner.real_name] claims victory!</span></div>"
+    else
+        to_chat(world, "<span class='ratvar'><font size=12>Something is bugged!</font></span>")
+        return "<div class='panel redborder'><span class='redtext big'>Winner:[winner] has an invalid value and couldn't be processed!</span></div>"

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -26,8 +26,8 @@
         return ..()
     if(length(active_players) == 0) //There are zero living players, round ends in draw
         winner = "draw"
-    else if(active_players[0]) //With all other options eliminated, there is only one living player, round ends with them victorious
-        winner = active_players[0]
+    else if(active_players[1]) //With all other options eliminated, there is only one living player, round ends with them victorious
+        winner = active_players[1]
     ..()
 
 /datum/game_mode/battle_royale/check_finished()

--- a/code/game/gamemodes/battleroyale/royale.dm
+++ b/code/game/gamemodes/battleroyale/royale.dm
@@ -14,6 +14,11 @@
 	    <span class='danger'>Mild banter is fine, but don't be toxic to others unless you want to be smited</span>"
     var/mob/winner
 
+/datum/game_mode/battle_royale/post_setup()
+    ..()
+    GLOB.battle_royale = new()
+    GLOB.battle_royale.start()
+
 /datum/game_mode/battle_royale/check_win()
     var/player_list = get_sentient_mobs()
     var/list/active_players = list()
@@ -21,7 +26,17 @@
     for(var/mob/player in player_list) //checking for all mobs instead of just humans
         if((!player.client) || (is_centcom_level(player.z)))
             continue
+        var/turf/T = get_turf(player)
+        if(T.x > 128 + GLOB.battle_royale.radius || T.x < 128 - GLOB.battle_royale.radius || T.y > 128 + GLOB.battle_royale.radius || T.y < 128 - GLOB.battle_royale.radius)
+            to_chat(player, "<span class='warning'>You have left the zone!</span>")
+            player.gib()
+            continue
+        if(!SSmapping.level_trait(T.z, ZTRAIT_STATION) && !SSmapping.level_trait(T.z, ZTRAIT_RESERVED))
+            to_chat(player, "<span class='warning'>You have somehow left the station!</span>")
+            player.gib()
+            continue
         active_players += player
+        CHECK_TICK
     if(length(active_players) > 1) //There are two or more living players, round continues
         return ..()
     if(length(active_players) == 0) //There are zero living players, round ends in draw
@@ -43,4 +58,4 @@
         return "<div class='panel redborder'><span class='greentext big'>[winner.real_name] claims victory!</span></div>"
     else
         to_chat(world, "<span class='ratvar'><font size=12>Something is bugged!</font></span>")
-        return "<div class='panel redborder'><span class='redtext big'>Winner:[winner] has an invalid value and couldn't be processed!</span></div>"
+        return "<div class='panel redborder'><span class='redtext big'>Winner:([winner]) has an invalid value and couldn't be processed!</span></div>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleans up the endscreen by removing information unnecessary for a battle royale server
Reports the victor's name on both the endscreen and in the chat, or reports a draw if everyone died
Implements the existing BR subsystem into the game mode, and comments out a lot of unnecessary code from it

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Brings the game mode from "minimum viable product" to the intended design goal. 

## Changelog
:cl:
add: Implements battle royale subsystem to track progress and provide loot drops
tweak: End of round reporting is now tailored to battle royale
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
