### PR TITLE
Auto transfer stat panel

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -342,7 +342,6 @@
 #include "code\_globalvars\lists\names.dm"
 #include "code\_globalvars\lists\objects.dm"
 #include "code\_globalvars\lists\poll_ignore.dm"
-#include "code\_globalvars\lists\subsystem.dm"
 #include "code\_globalvars\lists\traitor.dm"
 #include "code\_globalvars\lists\typecache.dm"
 #include "code\_globalvars\lists\wiremod.dm"

--- a/code/__HELPERS/stat_helpers.dm
+++ b/code/__HELPERS/stat_helpers.dm
@@ -4,3 +4,9 @@
 #define GENERATE_STAT_DIVIDER (list(type=STAT_DIVIDER))
 
 #define GENERATE_STAT_BLANK (list(type=STAT_BLANK))
+
+#define GENERATE_STAT_BUTTON(desired_text, desired_action) (list(\
+		text = desired_text,\
+		type = STAT_BUTTON,\
+		action = desired_action,\
+	))

--- a/code/_globalvars/lists/subsystem.dm
+++ b/code/_globalvars/lists/subsystem.dm
@@ -1,1 +1,0 @@
-GLOBAL_LIST_EMPTY(total_votes_to_leave)

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -7,12 +7,13 @@ SUBSYSTEM_DEF(autotransfer)
 	var/checkvotes_time
 	var/decay_start
 	var/decay_count = 0
-	var/list/connected_votes_to_leave = list()
-
+	var/connected_votes_to_leave = 0
+	var/required_votes_to_leave = 0
 
 /datum/controller/subsystem/autotransfer/Initialize()
 	reminder_time = REALTIMEOFDAY + CONFIG_GET(number/autotransfer_decay_start)
 	checkvotes_time = REALTIMEOFDAY + 5 MINUTES
+	required_votes_to_leave = length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
 
 	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
 		can_fire = FALSE
@@ -20,16 +21,20 @@ SUBSYSTEM_DEF(autotransfer)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/autotransfer/fire()
+	// Calculate always to account for disconnected/reconnected players
+	// Alternatively this could just hook into client/new and client/destroy, but
+	// it doesn't matter that much if we lose count for a bit
+	connected_votes_to_leave = 0
+	for(var/client/c in GLOB.clients)
+		if (c.player_details.voted_to_leave)
+			connected_votes_to_leave ++
+
 	if(REALTIMEOFDAY > checkvotes_time)
 		if(decay_start)
 			decay_count++
 
-		var/list/connected_ckeys = list()
-		for(var/client/c in GLOB.clients)
-			connected_ckeys += c.ckey
-		connected_votes_to_leave = connected_ckeys & GLOB.total_votes_to_leave
-
-		if(length(connected_votes_to_leave) >= (length(connected_ckeys) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)))
+		required_votes_to_leave = length(GLOB.clients) * (CONFIG_GET(number/autotransfer_percentage) - CONFIG_GET(number/autotransfer_decay_amount) * decay_count)
+		if(connected_votes_to_leave >= required_votes_to_leave)
 			if(SSshuttle.canEvac() == TRUE) //This must include the == TRUE because all returns for this proc have a value, we specifically want to check for TRUE
 				SSshuttle.requestEvac(null, "Crew Transfer Requested.")
 				SSshuttle.emergencyNoRecall = TRUE
@@ -42,5 +47,5 @@ SUBSYSTEM_DEF(autotransfer)
 	if(REALTIMEOFDAY > reminder_time)
 		decay_start = TRUE
 		sound_to_playing_players('sound/misc/server-ready.ogg')
-		to_chat(world, "\n<font color='purple'>Don't forget you can vote to leave in the OOC tab if you're ready for the round to end!</font>")
+		to_chat(world, "<font color='purple'>Don't forget you can vote to leave by pushing the button on the status tab if you're ready for the round to end!</font>")
 		reminder_time = reminder_time + CONFIG_GET(number/autotransfer_decay_start)

--- a/code/modules/client/player_details.dm
+++ b/code/modules/client/player_details.dm
@@ -6,6 +6,8 @@
 	var/list/played_names = list() //List of names this key played under this round
 	var/byond_version = "Unknown"
 	var/datum/achievement_data/achievements
+	/// Whether or not this client has voted to leave
+	var/voted_to_leave = FALSE
 
 /datum/player_details/New(key)
 	achievements = new(key)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -344,9 +344,11 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	set category = "OOC"
 	set desc = "Votes to end the round"
 
-	if(ckey in GLOB.total_votes_to_leave)
-		GLOB.total_votes_to_leave -= ckey
+	if(player_details.voted_to_leave)
+		player_details.voted_to_leave = FALSE
+		SSautotransfer.connected_votes_to_leave--
 		to_chat(src, "You are no longer voting for the current round to end.")
 	else
-		GLOB.total_votes_to_leave += ckey
+		player_details.voted_to_leave = TRUE
+		SSautotransfer.connected_votes_to_leave++
 		to_chat(src, "You are now voting for the current round to end.")

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -246,7 +246,7 @@
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
 	if (!isnewplayer(src) && SSautotransfer.can_fire)
-		if (SSautotransfer.required_votes_to_leave)
+		if (SSautotransfer.required_votes_to_leave && SSshuttle.canEvac())
 			tab_data["Vote to leave"] = GENERATE_STAT_BUTTON("[client?.player_details.voted_to_leave ? "Yes" : "No"] ([SSautotransfer.connected_votes_to_leave]/[CEILING(SSautotransfer.required_votes_to_leave, 1)])", "votetoleave")
 		else
 			tab_data["Vote to leave"] = GENERATE_STAT_BUTTON("[client?.player_details.voted_to_leave ? "Yes" : "No"]", "votetoleave")

--- a/code/modules/mob/mob_stat.dm
+++ b/code/modules/mob/mob_stat.dm
@@ -245,6 +245,11 @@
 		var/ETA = SSshuttle.emergency.getModeStr()
 		if(ETA)
 			tab_data[ETA] = GENERATE_STAT_TEXT(SSshuttle.emergency.getTimerStr())
+	if (!isnewplayer(src) && SSautotransfer.can_fire)
+		if (SSautotransfer.required_votes_to_leave)
+			tab_data["Vote to leave"] = GENERATE_STAT_BUTTON("[client?.player_details.voted_to_leave ? "Yes" : "No"] ([SSautotransfer.connected_votes_to_leave]/[CEILING(SSautotransfer.required_votes_to_leave, 1)])", "votetoleave")
+		else
+			tab_data["Vote to leave"] = GENERATE_STAT_BUTTON("[client?.player_details.voted_to_leave ? "Yes" : "No"]", "votetoleave")
 	return tab_data
 
 /mob/proc/get_stat_tab_master_controller()
@@ -446,6 +451,8 @@
 		if("start_br")
 			if(client.holder && check_rights(R_FUN))
 				client.battle_royale()
+		if ("votetoleave")
+			client.vote_to_leave()
 
 /*
  * Sets the current stat tab selected.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a stat panel button for the auto transfer PR.

It does not display when you are a new player, though you will still be able to vote while on the main menu through the verb.

Performs various optimisations, since the stat panel is a hot path we can't be doing `var in list` operations, so its better if we just cache the number of votes.

## Why It's Good For The Game

It makes it easier for players to vote to leave, and shows them how many people have voted to leave.

## Testing Photographs and Procedure

![image](https://github.com/user-attachments/assets/9fc0e179-cfb8-47a3-8e36-b3dea238fac2)

![image](https://github.com/user-attachments/assets/ce34fd2f-40a2-48df-81d7-9ab0dd783c71)

When the subsystem is disabled:

![image](https://github.com/user-attachments/assets/e9c088df-38ef-4722-a862-09405fd08245)

Before the evac shuttle is ready to leave, the number of votes required will not be displayed.

## Changelog
:cl:
add: Adds a status panel button for voting to leave.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
